### PR TITLE
Adjust names of overlaid projects

### DIFF
--- a/bpftrace_for_android.xml
+++ b/bpftrace_for_android.xml
@@ -4,13 +4,13 @@
 
   <project name="platform_external_flex" path="external/flex" remote="michalgr" revision="bpftrace_for_android"/>
 
-  <remove-project name="platform/external/xz-embedded"/>
+  <remove-project name="aosp/platform/external/xz-embedded"/>
   <project name="platform_external_xz-embedded" path="external/xz-embedded" remote="michalgr" revision="bpftrace_for_android"/>
 
-  <remove-project name="platform/external/toybox"/>
+  <remove-project name="aosp/platform/external/toybox"/>
   <project name="platform_external_toybox" path="external/toybox" remote="michalgr" revision="bpftrace_for_android"/>
 
-  <remove-project name="platform/external/elfutils"/>
+  <remove-project name="aosp/platform/external/elfutils"/>
   <project name="platform_external_elfutils" path="external/elfutils" remote="michalgr" revision="bpftrace_for_android_take9"/>
 
   <project name="platform_external_bison" path="external/bpftrace/bison3" remote="michalgr" revision="bpftrace_for_android_take8"/>


### PR DESCRIPTION
It appears that existing external projects were prefixed with `aosp/`.
Hence, when building with the existing manifest an error would ensue
because `platform/external/xz-embedded`, for example, cannot be found.

With this change we adjust our local manifest accordingly, prefixing
repositories in question as needed.